### PR TITLE
Fix image manager grid borders

### DIFF
--- a/lib/modules/apostrophe-images/public/css/grid-item.less
+++ b/lib/modules/apostrophe-images/public/css/grid-item.less
@@ -66,7 +66,7 @@
     color: @apos-black;
     text-decoration: none;
     font-size: 12px;
-    white-space: nowrap; 
+    white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
 
@@ -92,8 +92,8 @@
   &::before
   {
     position: absolute;
-    top: -2px;
-    left: -2px;
+    top: 0;
+    left: 0;
     width: ~'calc(100%)';  // add the border width
     height: ~'calc(100%)';
     border: 2px solid transparent;


### PR DESCRIPTION
The grid was hiding the border in the top left and right which I think is not intended.

This also affected the position of the image, being ~2px more to the right than it should.